### PR TITLE
Align world API usage and unify POI schema

### DIFF
--- a/astraweave-core/src/perception.rs
+++ b/astraweave-core/src/perception.rs
@@ -1,4 +1,5 @@
 use crate::{World, WorldSnapshot, PlayerState, CompanionState, EnemyState, IVec2, Entity};
+use crate::schema::Poi;
 use std::collections::BTreeMap;
 
 pub struct PerceptionConfig {
@@ -22,8 +23,14 @@ pub fn build_snapshot(
         orders: vec!["hold_east".into()],
     };
     let me = CompanionState {
-        ammo: w.ammo_mut(t_companion).unwrap().rounds,
-        cooldowns: w.cooldowns_mut(t_companion).unwrap().map.clone().into_iter().collect::<BTreeMap<_,_>>(),
+        ammo: w.ammo(t_companion).unwrap().rounds,
+        cooldowns: w
+            .cooldowns(t_companion)
+            .unwrap()
+            .map
+            .clone()
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
         morale: 0.8,
         pos: cpos,
     };
@@ -37,10 +44,13 @@ pub fn build_snapshot(
 
     WorldSnapshot {
         t: w.t,
-        player, me, enemies, pois: vec![Poi{k:"breach_door".into(), pos: IVec2{x:15,y:8}}],
+        player,
+        me,
+        enemies,
+        pois: vec![Poi {
+            k: "breach_door".into(),
+            pos: IVec2 { x: 15, y: 8 },
+        }],
         objective,
     }
 }
-
-#[derive(Clone)]
-pub struct Poi { pub k: String, pub pos: IVec2 }

--- a/astraweave-core/src/tools.rs
+++ b/astraweave-core/src/tools.rs
@@ -1,11 +1,10 @@
-use crate::Entity;
 use serde::{Serialize, Deserialize};
 use std::collections::{HashMap, HashSet};
 // Import glam::IVec2 with an alias to avoid name conflicts
 use glam::IVec2 as GlamIVec2;
 
 #[derive(Debug, Clone)]
-pub struct Poi {
+pub struct ToolPoi {
     /// Unique key or name for the POI
     pub key: String,
     /// Grid or world position of the POI
@@ -175,8 +174,6 @@ pub fn find_cover_positions(
 ) -> Vec<crate::IVec2> {
     // Convert schema::IVec2 to glam::IVec2
     let from_glam = schema_to_glam(from);
-    let player_glam = schema_to_glam(player);
-    let enemy_glam = schema_to_glam(enemy);
     
     let (minx,miny,maxx,maxy) = bounds;
     let mut out = vec![];

--- a/astraweave-core/src/validation.rs
+++ b/astraweave-core/src/validation.rs
@@ -15,17 +15,17 @@ pub fn validate_and_execute(
     for (i, step) in intent.steps.iter().enumerate() {
         match step {
             ActionStep::MoveTo { x, y } => {
-                let from = w.position_of(actor).unwrap();
-                let to = IVec2{x:*x, y:*y};
+                let from = w.pos_of(actor).unwrap();
+                let to = IVec2 { x: *x, y: *y };
                 if !path_exists(&w.obstacles, from, to, cfg.world_bounds) {
                     return Err(EngineError::NoPath);
                 }
-                w.pose_mut(actor).unwrap().position = to;
-                log(format!("  [{}] MOVE_TO -> ({},{})", i, x,y));
+                w.pose_mut(actor).unwrap().pos = to;
+                log(format!("  [{}] MOVE_TO -> ({},{})", i, x, y));
             }
             ActionStep::Throw { item, x, y } => {
-                let from = w.position_of(actor).unwrap();
-                let target = IVec2{x:*x, y:*y};
+                let from = w.pos_of(actor).unwrap();
+                let target = IVec2 { x: *x, y: *y };
                 if !los_clear(&w.obstacles, from, target) {
                     return Err(EngineError::LosBlocked);
                 }
@@ -38,8 +38,10 @@ pub fn validate_and_execute(
                 log(format!("  [{}] THROW {} -> ({},{})", i, item, x,y));
             }
             ActionStep::CoverFire { target_id, duration } => {
-                let my = w.position_of(actor).unwrap();
-                let tgt = w.position_of(*target_id).ok_or_else(|| EngineError::InvalidAction("target gone".into()))?;
+                let my = w.pos_of(actor).unwrap();
+                let tgt = w
+                    .pos_of(*target_id)
+                    .ok_or_else(|| EngineError::InvalidAction("target gone".into()))?;
                 if !los_clear(&w.obstacles, my, tgt) {
                     return Err(EngineError::LosBlocked);
                 }

--- a/astraweave-core/src/world.rs
+++ b/astraweave-core/src/world.rs
@@ -58,7 +58,9 @@ impl World {
     pub fn health(&self, e: Entity) -> Option<Health> { self.health.get(&e).copied() }
     pub fn health_mut(&mut self, e: Entity) -> Option<&mut Health> { self.health.get_mut(&e) }
     pub fn team(&self, e: Entity) -> Option<Team> { self.team.get(&e).copied() }
+    pub fn ammo(&self, e: Entity) -> Option<Ammo> { self.ammo.get(&e).copied() }
     pub fn ammo_mut(&mut self, e: Entity) -> Option<&mut Ammo> { self.ammo.get_mut(&e) }
+    pub fn cooldowns(&self, e: Entity) -> Option<&Cooldowns> { self.cds.get(&e) }
     pub fn cooldowns_mut(&mut self, e: Entity) -> Option<&mut Cooldowns> { self.cds.get_mut(&e) }
     pub fn name(&self, e: Entity) -> Option<&str> { self.names.get(&e).map(|s| s.as_str()) }
 


### PR DESCRIPTION
## Summary
- switch validation to new `pos_of` API and pose fields
- use schema `Poi` and immutably borrow world data in perception
- rename tools `Poi` to `ToolPoi` and prune unused code
- add read-only getters for ammo and cooldowns

## Testing
- `cargo test -p astraweave-core`
- `cargo test` *(fails: could not compile `astraweave-nav`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb60e5b4e08322b81c669ba7788d5e